### PR TITLE
Enable automatic account linking for OAuth

### DIFF
--- a/server/lib/auth.ts
+++ b/server/lib/auth.ts
@@ -88,11 +88,13 @@ export async function useAuthOptions (event: H3Event): Promise<AuthConfig> {
       } as unknown as EmailConfig,
       GoogleProvider({
         clientId: globalThis.__env__.NUXT_GOOGLE_CLIENT_ID,
-        clientSecret: globalThis.__env__.NUXT_GOOGLE_CLIENT_SECRET
+        clientSecret: globalThis.__env__.NUXT_GOOGLE_CLIENT_SECRET,
+        allowDangerousEmailAccountLinking: true
       }),
       GithubProvider({
         clientId: globalThis.__env__.NUXT_GITHUB_CLIENT_ID,
-        clientSecret: globalThis.__env__.NUXT_GITHUB_CLIENT_SECRET
+        clientSecret: globalThis.__env__.NUXT_GITHUB_CLIENT_SECRET,
+        allowDangerousEmailAccountLinking: true
       })
     ],
     trustHost: true,


### PR DESCRIPTION
## Summary
- allow automatic account linking via OAuth when using Google and GitHub

## Testing
- `npm run lint:scripts`
- `npm run lint:styles` *(fails: Expected `color` to come before `background-clip` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68433d3a627c832bb8d411d4618754e4