### PR TITLE
Enable navigation to tracked shows from search

### DIFF
--- a/app/components/show.vue
+++ b/app/components/show.vue
@@ -44,7 +44,7 @@
 </style>
 
 <template>
-  <nuxt-link :class="['show', {'shouldGoToShow': shouldGoToShow}]" :href="shouldGoToShow ? `/show/${show.id}` : ''">
+  <nuxt-link :class="['show', {'shouldGoToShow': computedShouldGoToShow}]" :href="computedShouldGoToShow ? `/show/${show.id}` : ''">
     <img class="show__image" :src="`/images?u=${encodeURIComponent(show.image_thumbnail_path?.replace('thumbnail', 'full') ?? 'https://placehold.co/250x600')}&w=250&h=375`" width="250" :loading="index < 10 ? 'eager' : 'lazy'">
     <div class="show__description">
       <h3>{{ show.name }}</h3>
@@ -83,6 +83,11 @@ export default defineComponent({
     index: {
       type: Number,
       default: 0
+    }
+  },
+  computed: {
+    computedShouldGoToShow (): boolean {
+      return this.shouldGoToShow || this.show.tracked
     }
   }
 })


### PR DESCRIPTION
## Summary
- allow navigation to show pages when a search result is already tracked

## Testing
- `pnpm run lint:scripts`
- `pnpm run lint:styles` *(fails: order/properties-order issues)*
- `pnpm run typecheck` *(fails: 403 Forbidden when fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68433d612308832ba5954536462a31db