### PR TITLE
Add custom confirm dialog

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -4,5 +4,6 @@
     <NuxtLayout>
       <NuxtPage />
     </NuxtLayout>
+    <ConfirmDialog />
   </div>
 </template>

--- a/app/components/confirmDialog.vue
+++ b/app/components/confirmDialog.vue
@@ -1,0 +1,47 @@
+<style lang="scss" scoped>
+.confirm__overlay {
+  position: fixed;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgb(0 0 0 / 40%);
+  backdrop-filter: blur(5px);
+  inset: 0
+}
+.confirm__dialog {
+  padding: 1rem;
+  text-align: center;
+  background-color: #1C1C1C;
+  border: 1px solid #333333;
+  border-radius: .5rem
+}
+.confirm__actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1rem
+}
+</style>
+
+<template>
+  <Teleport to="body">
+    <div v-if="visible" class="confirm__overlay" @click.self="cancel">
+      <div class="confirm__dialog">
+        <p>{{ message }}</p>
+        <div class="confirm__actions">
+          <button class="button" type="button" @click="confirm">
+            Ok
+          </button>
+          <button class="button" type="button" @click="cancel">
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script lang="ts" setup>
+const { visible, message, confirm, cancel } = useConfirm()
+</script>

--- a/app/components/showButtons.vue
+++ b/app/components/showButtons.vue
@@ -2,13 +2,13 @@
 .show__button-container {
   position: absolute;
   z-index: 2;
-  inset: 0;
-  background-image: linear-gradient(180deg, rgba(0,0,0,.9) 0%, rgba(0,0,0,0.5) 70%, rgba(0,0,0,0) 100%);
-  backdrop-filter: blur(1px);
-  height: fit-content;
   display: flex;
   justify-content: flex-end;
+  height: fit-content;
   padding: 1rem .5rem;
+  background-image: linear-gradient(180deg, rgb(0 0 0 / 90%) 0%, rgb(0 0 0 / 50%) 70%, rgb(0 0 0 / 0%) 100%);
+  backdrop-filter: blur(1px);
+  inset: 0
 }
 .button {
   width: 1rem;
@@ -96,7 +96,10 @@ export default defineComponent({
       }
     },
     async deleteShow () {
-      if (typeof window !== 'undefined' && window.confirm('Are you sure you want to delete this show?')) {
+      const { open } = useConfirm()
+      const confirmed = await open('Are you sure you want to delete this show?')
+
+      if (confirmed) {
         const headers = useRequestHeaders(['cookie']) as HeadersInit
         const response = await fetch(`/api/show/${this.id}`, {
           method: 'DELETE',

--- a/composables/useConfirm.ts
+++ b/composables/useConfirm.ts
@@ -1,0 +1,33 @@
+import { ref } from 'vue'
+
+const visible = ref(false)
+const message = ref('')
+let resolver: ((value: boolean) => void) | null = null
+
+export default function useConfirm () {
+  const open = (msg: string) => {
+    message.value = msg
+    visible.value = true
+    return new Promise<boolean>((resolve) => {
+      resolver = resolve
+    })
+  }
+
+  const confirm = () => {
+    visible.value = false
+    resolver?.(true)
+  }
+
+  const cancel = () => {
+    visible.value = false
+    resolver?.(false)
+  }
+
+  return {
+    visible,
+    message,
+    open,
+    confirm,
+    cancel
+  }
+}


### PR DESCRIPTION
## Summary
- implement `useConfirm` composable and `ConfirmDialog` component
- embed dialog component in the app root
- use the new confirm in `showButtons.vue` when deleting a show
- address comment about Nuxt auto-importing components

## Testing
- `pnpm lint:scripts`
- `pnpm lint:styles`
- `pnpm typecheck` *(fails: requires vue-tsc download)*

------
https://chatgpt.com/codex/tasks/task_e_68433d4c4880832ba8f0f0e463a23e4a