### PR TITLE
Define caches for Nitro dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tv-shows",
   "private": true,
-  "packageManager": "pnpm@10.11.1",
+  "packageManager": "pnpm@10.11.1+sha512.e519b9f7639869dc8d5c3c5dfef73b3f091094b0a006d7317353c72b124e80e1afd429732e28705ad6bfa1ee879c1fce46c128ccebd3192101f43dd67c667912",
   "type": "module",
   "scripts": {
     "build": "nuxi build",
@@ -64,9 +64,8 @@
   ],
   "pnpm": {
     "patchedDependencies": {
-      "@auth/core@0.18.6": "patches/@auth__core@0.18.6.patch"
-      ,"nitro-cloudflare-dev@0.2.2": "patches/nitro-cloudflare-dev@0.2.2.patch"
+      "@auth/core@0.18.6": "patches/@auth__core@0.18.6.patch",
+      "nitro-cloudflare-dev@0.2.2": "patches/nitro-cloudflare-dev@0.2.2.patch"
     }
-  },
-  "packageManager": "pnpm@10.11.1+sha512.e519b9f7639869dc8d5c3c5dfef73b3f091094b0a006d7317353c72b124e80e1afd429732e28705ad6bfa1ee879c1fce46c128ccebd3192101f43dd67c667912"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "pnpm": {
     "patchedDependencies": {
       "@auth/core@0.18.6": "patches/@auth__core@0.18.6.patch"
+      ,"nitro-cloudflare-dev@0.2.2": "patches/nitro-cloudflare-dev@0.2.2.patch"
     }
   },
   "packageManager": "pnpm@10.11.1+sha512.e519b9f7639869dc8d5c3c5dfef73b3f091094b0a006d7317353c72b124e80e1afd429732e28705ad6bfa1ee879c1fce46c128ccebd3192101f43dd67c667912"

--- a/patches/nitro-cloudflare-dev@0.2.2.patch
+++ b/patches/nitro-cloudflare-dev@0.2.2.patch
@@ -1,0 +1,16 @@
+diff --git a/dist/runtime/plugin.dev.mjs b/dist/runtime/plugin.dev.mjs
+index 9e44a03daf9c415bc806af8d99e6dbec15ee9f01..8be8123412cf856a145b9341cdec137f13c8e7bc 100644
+--- a/dist/runtime/plugin.dev.mjs
++++ b/dist/runtime/plugin.dev.mjs
+@@ -4,9 +4,11 @@
+   return _createStubProxy();
+ }).then((proxy) => {
+   globalThis.__env__ = proxy.env;
++  globalThis.caches = proxy.caches;
+   return proxy;
+ });
+ globalThis.__env__ = _proxy.then((proxy) => proxy.env);
++globalThis.caches = _proxy.then((proxy) => proxy.caches);
+ export default (function(nitroApp) {
+   nitroApp.hooks.hook("request", async (event) => {
+     const proxy = await _proxy;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   '@auth/core@0.18.6':
     hash: e9e5c7351088a10712f5137704df989652af8da0593a16b7f982a9441d1515b4
     path: patches/@auth__core@0.18.6.patch
+  nitro-cloudflare-dev@0.2.2:
+    hash: ad531df3bb71c3d0533d92a86533f708cd670078c4c90533cf979de7282d0f56
+    path: patches/nitro-cloudflare-dev@0.2.2.patch
 
 importers:
 
@@ -87,7 +90,7 @@ importers:
         version: 3.7.7
       nitro-cloudflare-dev:
         specifier: ^0.2.2
-        version: 0.2.2
+        version: 0.2.2(patch_hash=ad531df3bb71c3d0533d92a86533f708cd670078c4c90533cf979de7282d0f56)
       nitropack:
         specifier: ^2.11.12
         version: 2.11.12(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20250607.0))
@@ -10675,7 +10678,7 @@ snapshots:
       p-wait-for: 5.0.2
       qs: 6.14.0
 
-  nitro-cloudflare-dev@0.2.2:
+  nitro-cloudflare-dev@0.2.2(patch_hash=ad531df3bb71c3d0533d92a86533f708cd670078c4c90533cf979de7282d0f56):
     dependencies:
       consola: 3.4.2
       mlly: 1.7.4


### PR DESCRIPTION
## Summary
- patch nitro-cloudflare-dev runtime plugin to expose `caches`

## Testing
- `pnpm run lint:scripts`


------
https://chatgpt.com/codex/tasks/task_e_684417ee6e18832baf85aaece2eba599