### PR TITLE
Enable Cloudflare preview for PRs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,13 @@
+name: Setup
+runs:
+  using: 'composite'
+  steps:
+    - uses: pnpm/action-setup@v2
+      with:
+        version: 10.11.1
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22.16.0
+        cache: 'pnpm'
+    - run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,38 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - name: Build
+        run: pnpm build
+      - name: Deploy preview
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: "deploy --name tv-shows-pr-${{ github.event.number }}"
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Comment preview URL
+        if: steps.deploy.outputs.deployment-url
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: `Preview deployment available at ${ steps.deploy.outputs['deployment-url'] }`
+            })
+

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -25,14 +25,17 @@ jobs:
           command: "deploy --name tv-shows-pr-${{ github.event.number }}"
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
       - name: Comment preview URL
-        if: steps.deploy.outputs.deployment-url
+        if: ${{ steps.deploy.outputs.deployment-url }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const url = process.env.DEPLOY_URL
             github.rest.issues.createComment({
               ...context.repo,
               issue_number: context.issue.number,
-              body: `Preview deployment available at ${ steps.deploy.outputs['deployment-url'] }`
+              body: `Preview deployment available at ${url}`
             })
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
 

--- a/app/components/episode.vue
+++ b/app/components/episode.vue
@@ -1,11 +1,11 @@
 <style lang="scss" scoped>
 button {
   padding: 0;
+  text-align: left;
   background: none;
   border: none;
   border-radius: 0;
-  cursor: pointer;
-  text-align: left
+  cursor: pointer
 }
 .watched {
   color: var(--greenColor)

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,11 @@ The TV show is green for currently airing. Red for canceled/finished. And has no
 
 There is a live calendar link available so you can sync with services like Google Calendar. Google Calendar isn't very reliable when syncing from a URL, so custom functionality is currently being built.
 
+## Preview Deployments
+
+Pull requests automatically deploy to a temporary Cloudflare Worker so reviewers can test changes before merge. The URL is posted as a comment on the PR.
+
+
 ## Develop
 
 ``` pnpm run dev ```


### PR DESCRIPTION
## Summary
- deploy each pull request to Cloudflare with a new GitHub Action
- explain how preview deployments work in the README
- fix style issues in episode.vue
- reuse a composite `setup` action in the preview workflow
- remove configurable version inputs and pin Node/pnpm versions

## Testing
- `pnpm lint:scripts`
- `pnpm lint:styles`
- `pnpm typecheck` *(fails: Could not find declaration files and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68441ea9d470832b8001f1b7863fd28c