### PR TITLE
Delete PR preview on close

### DIFF
--- a/.github/workflows/pr-preview-delete.yml
+++ b/.github/workflows/pr-preview-delete.yml
@@ -1,0 +1,35 @@
+name: Delete PR Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - name: Delete preview
+        id: delete
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: "delete tv-shows-pr-${{ github.event.number }}"
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Comment deletion
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: 'Preview deployment deleted.'
+            })


### PR DESCRIPTION
## Summary
- delete Cloudflare preview deployment when PR is closed

## Testing
- `pnpm lint:scripts`


------
https://chatgpt.com/codex/tasks/task_e_6844285214f8832b95582fed43a70df6