### PR TITLE
Fix auth origin for preview deployments

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,9 @@ There is a live calendar link available so you can sync with services like Googl
 
 Pull requests automatically deploy to a temporary Cloudflare Worker so reviewers can test changes before merge. The URL is posted as a comment on the PR.
 
+Cloudflare automatically sets `CF_PAGES_URL` during preview deployments.
+Ensure this variable or `NUXT_PUBLIC_AUTH_JS_BASE_URL` is available to your worker so Auth JS can validate request origins.
+
 
 ## Develop
 

--- a/server/api/auth/[...].ts
+++ b/server/api/auth/[...].ts
@@ -14,7 +14,10 @@ export default defineEventHandler(async (event: H3Event): Promise<ResponseIntern
   if (request.method === 'POST') {
     const requestOrigin = request.headers.get('Origin')
 
-    const serverOrigin = globalThis.__env__.NUXT_PUBLIC_AUTH_JS_BASE_URL
+    // Prefer explicit config and fall back to Cloudflare's preview URL
+    const serverOrigin =
+      globalThis.__env__.NUXT_PUBLIC_AUTH_JS_BASE_URL ??
+      globalThis.__env__.CF_PAGES_URL
 
     if (serverOrigin !== requestOrigin) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
- fallback to the Cloudflare preview url when `NUXT_PUBLIC_AUTH_JS_BASE_URL` is unset
- document required environment variable for PR previews

## Testing
- `pnpm lint:scripts`
- `pnpm lint:styles`
- `pnpm typecheck` *(fails: Process exited with non-zero status (2))*

------
https://chatgpt.com/codex/tasks/task_e_68442c9b19e0832b9f619ec6ff10d8f2