### PR TITLE
Add postinstall script to generate auth secret

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "migrations:apply:local": "wrangler d1 migrations apply tv_shows --local",
     "migrations:list:remote": "wrangler d1 migrations list tv_shows --remote",
     "migrations:apply:remote": "wrangler d1 migrations apply tv_shows --remote",
-    "postinstall": "nuxi prepare && openssl rand -base64 32 | tr -d '\n' | sed 's/^/NUXT_AUTH_JS_SECRET=/' > .dev.vars",
+    "postinstall": "nuxi prepare && node ./scripts/postinstall.js",
     "lint:scripts": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "fix:scripts": "eslint --ext .js,.vue --ignore-path .gitignore . --fix",
     "lint:styles": "stylelint \"**/*.{vue,scss}\"",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "migrations:apply:local": "wrangler d1 migrations apply tv_shows --local",
     "migrations:list:remote": "wrangler d1 migrations list tv_shows --remote",
     "migrations:apply:remote": "wrangler d1 migrations apply tv_shows --remote",
-    "postinstall": "nuxi prepare",
+    "postinstall": "nuxi prepare && openssl rand -base64 32 | tr -d '\n' | sed 's/^/NUXT_AUTH_JS_SECRET=/' > .dev.vars",
     "lint:scripts": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "fix:scripts": "eslint --ext .js,.vue --ignore-path .gitignore . --fix",
     "lint:styles": "stylelint \"**/*.{vue,scss}\"",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import { existsSync, writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
+import { resolve } from 'node:path'
+
+const file = resolve(process.cwd(), '.dev.vars')
+
+if (existsSync(file)) {
+  console.log('.dev.vars already exists, skipping secret generation.')
+  process.exit(0)
+}
+
+let secret = ''
+try {
+  secret = execSync('openssl rand -base64 32').toString().trim()
+} catch (err) {
+  console.warn('OpenSSL not found, using Node crypto as fallback.')
+  secret = randomBytes(32).toString('base64')
+}
+
+writeFileSync(file, `NUXT_AUTH_JS_SECRET=${secret}\n`, { flag: 'wx' })
+console.log('Secret written to .dev.vars')


### PR DESCRIPTION
## Summary
- generate a random secret for auth and save to `.dev.vars`

## Testing
- `pnpm run lint:scripts`
- `pnpm run lint:styles`
- `pnpm run typecheck` *(fails: Process exited with non-zero status 2)*

------
https://chatgpt.com/codex/tasks/task_e_6844384e5808832b9268ebe7b8392448