### PR TITLE
Fix ESLint errors

### DIFF
--- a/server/lib/getEpisodesForShow.ts
+++ b/server/lib/getEpisodesForShow.ts
@@ -24,6 +24,7 @@ export async function getEpisodesForShow (showId: number, userEmail: string, eve
     season: episodes.season,
     episode: episodes.episode,
     name: episodes.name,
+    // eslint-disable-next-line camelcase
     air_date: episodes.air_date,
     episodateTvShowId: episodes.episodateTvShowId,
     watched: sql<boolean>`${isNotNull(watched.episodeId)}`

--- a/server/lib/getShowsForUser.ts
+++ b/server/lib/getShowsForUser.ts
@@ -15,6 +15,7 @@ export const getShowsForUser = async (userEmail: string): Promise<Show[]> => {
 
   return await DB.selectDistinct({
     name: episodes.name,
+    // eslint-disable-next-line camelcase
     air_date: episodes.air_date,
     showName: sql<string>`${episodateTvShows.name} as showName`,
     showId: episodateTvShows.id

--- a/server/lib/syncShow.ts
+++ b/server/lib/syncShow.ts
@@ -22,17 +22,24 @@ export async function syncShow (showId: number): Promise<void> {
     permalink: tvShow.permalink,
     url: tvShow.url,
     description: tvShow.description,
+    // eslint-disable-next-line camelcase
     description_source: tvShow.description_source,
+    // eslint-disable-next-line camelcase
     start_date: tvShow.start_date,
+    // eslint-disable-next-line camelcase
     end_date: tvShow.end_date,
     country: tvShow.country,
     status: tvShow.status,
     runtime: tvShow.runtime,
     network: tvShow.network,
+    // eslint-disable-next-line camelcase
     youtube_link: tvShow.youtube_link,
+    // eslint-disable-next-line camelcase
     image_path: tvShow.image_path,
+    // eslint-disable-next-line camelcase
     image_thumbnail_path: tvShow.image_thumbnail_path,
     rating: tvShow.rating,
+    // eslint-disable-next-line camelcase
     rating_count: tvShow.rating_count,
     genres: tvShow.genres.join(','),
     pictures: tvShow.pictures.join(','),
@@ -58,6 +65,7 @@ export async function syncShow (showId: number): Promise<void> {
           season: episode.season,
           episode: episode.episode,
           name: episode.name,
+          // eslint-disable-next-line camelcase
           air_date: episode.air_date,
           episodateTvShowId: tvShow.id
         })
@@ -65,6 +73,7 @@ export async function syncShow (showId: number): Promise<void> {
           target: [episodes.episodateTvShowId, episodes.episode, episodes.season],
           set: {
             name: episode.name,
+            // eslint-disable-next-line camelcase
             air_date: episode.air_date
           }
         })

--- a/server/routes/images.ts
+++ b/server/routes/images.ts
@@ -2,11 +2,11 @@ import type { H3Event } from 'h3'
 import type { Cache, Response as CloudflareResponse } from '@cloudflare/workers-types'
 
 interface WasmImageModule {
-  init: undefined | Function
+  init?: (module: WebAssembly.Module) => unknown
 }
 
 interface WasmResizeModule {
-  initResize: undefined | Function
+  initResize?: (module: WebAssembly.Module) => unknown
 }
 
 async function loadWasmModule (wasmPath: string, module: WasmImageModule|WasmResizeModule): Promise<void> {

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -1,11 +1,11 @@
 declare module 'nuxt-component-pagination' {
   import type { DefineComponent } from 'vue'
-  const component: DefineComponent<Record<string, never>, {}, any>
+  const component: DefineComponent<Record<string, never>, Record<string, never>, any>
   export default component
 }
 
 declare module 'nuxt-component-date/index.vue' {
   import type { DefineComponent } from 'vue'
-  const component: DefineComponent<Record<string, never>, {}, any>
+  const component: DefineComponent<Record<string, never>, Record<string, never>, any>
   export default component
 }


### PR DESCRIPTION
## Summary
- fix strict function types for wasm modules
- adjust Vue component typings
- silence camelcase complaints for DB field names

## Testing
- `npm run lint:scripts`

------
https://chatgpt.com/codex/tasks/task_e_68447a5f8344832b9285e1cc41d2e6a6