### PR TITLE
Enable offline fallback for PWA

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -58,10 +58,14 @@ export default defineNuxtConfig({
     registerType: 'autoUpdate',
     manifest: {
       name: 'TV Shows',
+      // eslint-disable-next-line camelcase
       short_name: 'TV Shows',
+      // eslint-disable-next-line camelcase
       theme_color: '#ffffff',
+      // eslint-disable-next-line camelcase
       background_color: '#ffffff',
       display: 'standalone',
+      // eslint-disable-next-line camelcase
       start_url: '/',
       icons: [
         {
@@ -77,7 +81,7 @@ export default defineNuxtConfig({
       ]
     },
     workbox: {
-      navigateFallback: null,
+      navigateFallback: '/',
       runtimeCaching: [
         {
           urlPattern: /\/api\/.*$/,


### PR DESCRIPTION
## Summary
- update workbox settings so navigation requests fallback to `/`
- silence linter errors in Nuxt manifest section

## Testing
- `pnpm lint:scripts`
- `pnpm lint:styles`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684494f7c1a4832bb2d3710cb32bd97b