### PR TITLE
Add sorting by episode dates

### DIFF
--- a/app/pages/my-shows.vue
+++ b/app/pages/my-shows.vue
@@ -41,6 +41,12 @@
         <option value="episodesToWatch">
           Episodes to watch
         </option>
+        <option value="nextEpisodeDate">
+          Next episode date
+        </option>
+        <option value="firstEpisodeDate">
+          First episode date
+        </option>
       </select>
       <button type="button" class="sort-order-btn" @click="toggleOrder">
         {{ route.query.order === 'desc' ? '▼' : '▲' }}


### PR DESCRIPTION
## Summary
- add future and first episode sorting
- wire new options to TV shows view
- avoid unnecessary joins when sorting

## Testing
- `pnpm lint:scripts`
- `pnpm lint:styles`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684e9a42f8c0832bb5cf339dc60cebfc