### PR TITLE
Stop navigating when clicking show action buttons

### DIFF
--- a/app/components/showButtons.vue
+++ b/app/components/showButtons.vue
@@ -42,8 +42,8 @@
 
 <template>
   <div class="show__button-container">
-    <button v-if="!tracked" type="button" class="button add" @click.stop="addShow()" />
-    <button v-else type="button" class="button remove" @click.stop="deleteShow()" />
+    <button v-if="!tracked" type="button" class="button add" @click.stop.prevent="addShow()" />
+    <button v-else type="button" class="button remove" @click.stop.prevent="deleteShow()" />
   </div>
 </template>
 

--- a/server/api/shows.get.ts
+++ b/server/api/shows.get.ts
@@ -1,6 +1,7 @@
 import type { H3Event } from 'h3'
 import { asc, desc, eq, inArray, and, countDistinct, gt, sql, notInArray, lte } from 'drizzle-orm'
-import { alias, type SQLiteSelect } from 'drizzle-orm/sqlite-core'
+import { alias } from 'drizzle-orm/sqlite-core'
+import type { SQLiteSelect } from 'drizzle-orm/sqlite-core'
 import { getAuthenticatedUserEmail } from '../lib/auth'
 import { tvShows, users, episodateTvShows, episodes, watchedEpisodes } from '../db/schema'
 import { pageSize as ps } from '../api/shows.get'


### PR DESCRIPTION
## Summary
- Prevent show buttons from triggering page navigation by cancelling default click behavior
- Use a dedicated type-only import for `SQLiteSelect` to satisfy lint rule

## Testing
- `pnpm lint:scripts`
- `pnpm lint:styles` (fails: Unknown rule color-function-alias-notation and others)
- `pnpm typecheck` (fails: Cannot find name 'EpisodateSearch', 'CustomSearch', '__env__', etc.)

------
https://chatgpt.com/codex/tasks/task_e_68c01ba9b180832bae18c200ed3fdade